### PR TITLE
Incompatibility or no relocated dependencies alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <version>4.0.3</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 
@@ -92,8 +93,16 @@
                                 <relocation>
                                     <pattern>com.zaxxer.hikari</pattern>
                                     <shadedPattern>pk.ajneb97.libs.hikaricp</shadedPattern>
+                                    <includes>
+                                        <include>com.zaxxer.hikari.**</include>
+                                    </includes>
+                                </relocation>
+                                <relocation>
                                     <pattern>org.slf4j</pattern>
                                     <shadedPattern>pk.ajneb97.libs.slf4j</shadedPattern>
+                                    <includes>
+                                        <include>org.slf4j.**</include>
+                                    </includes>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,10 @@
                         <configuration>
                             <relocations>
                                 <relocation>
-                                    <pattern>com.zaxxer.HikariCP</pattern>
+                                    <pattern>com.zaxxer.hikari</pattern>
                                     <shadedPattern>pk.ajneb97.libs.hikaricp</shadedPattern>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>pk.ajneb97.libs.slf4j</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -97,13 +97,6 @@
                                         <include>com.zaxxer.hikari.**</include>
                                     </includes>
                                 </relocation>
-                                <relocation>
-                                    <pattern>org.slf4j</pattern>
-                                    <shadedPattern>pk.ajneb97.libs.slf4j</shadedPattern>
-                                    <includes>
-                                        <include>org.slf4j.**</include>
-                                    </includes>
-                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 main: pk.ajneb97.PlayerKits2
-version: 1.8.3
+version: 1.8.4
 name: PlayerKits2
 api-version: 1.13
 softdepend: [Vault,PlaceholderAPI]


### PR DESCRIPTION
## Problem
It is evident that when trying to turn on a server with this plugin present, other plugins that contain dependency detectors in their code, PlayerKits2 does not have correct relocations.

![image](https://github.com/Ajneb97/PlayerKits2/assets/89610430/1f6c2bd0-1700-4294-8344-9fa850bd70fe)

## Because it is important?

As the information presented by the "LibertyBans" plugin, this may cause incompatibility or dependency failures with other plugins, or simply not start.

## Solution

Some small changes are made to the dependency manager, correctly carrying out the relocations, giving good results.

![image](https://github.com/Ajneb97/PlayerKits2/assets/89610430/23566d2a-8b32-421f-9bc1-96a6dbfabe97)

## Extra

A version upload is made, as it is an important change, it is taken into account in the nomenclature for versioning in git