### PR TITLE
Hikari pool configuration improve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.1</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/pk/ajneb97/database/HikariConnection.java
+++ b/src/main/java/pk/ajneb97/database/HikariConnection.java
@@ -2,22 +2,99 @@ package pk.ajneb97.database;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.apache.logging.log4j.util.Strings;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 public class HikariConnection {
 
-    private HikariDataSource hikari;
+    private final HikariDataSource hikari;
+    private final String database;
 
-    public HikariConnection(String ip, int port, String database, String username, String password) {
+    public HikariConnection(ConfigurationSection configSection) throws URISyntaxException {
         HikariConfig config = new HikariConfig();
-        config.setJdbcUrl("jdbc:mysql://" + ip + ":" + port + "/" + database);
-        config.setUsername(username);
-        config.setPassword(password);
+        this.database = configSection.getString("database", "database");
+        URI databaseUri = buildDatabaseUri(configSection);
+        config.setJdbcUrl(databaseUri.toString());
+        config.setUsername(configSection.getString("username", "root"));
+        config.setPassword(configSection.getString("password", "root"));
+        ConfigurationSection driverSection = configSection.getConfigurationSection("driver_properties");
+        if (driverSection != null) {
+            setAdditionalProperties(config, driverSection);
+        }
+        ConfigurationSection hikariSection = configSection.getConfigurationSection("driver_properties");
+        if (hikariSection != null) {
+            setHikariProperties(hikariSection, config);
+        }
+        hikari = new HikariDataSource(config);
+    }
+
+    private void setAdditionalProperties(HikariConfig config, ConfigurationSection section) {
         config.addDataSourceProperty("autoReconnect", "true");
         config.addDataSourceProperty("leakDetectionThreshold", "true");
         config.addDataSourceProperty("verifyServerCertificate", "false");
         config.addDataSourceProperty("useSSL", "false");
-        config.setConnectionTimeout(5000);
-        hikari = new HikariDataSource(config);
+        for (String key : section.getKeys(false)) {
+            String value = section.getString(key);
+            if (Strings.isBlank(value)) continue;
+            config.addDataSourceProperty(key, value);
+        }
+    }
+
+    private void setHikariProperties(ConfigurationSection section, HikariConfig config) {
+        setLongValue(section, config, "connection_timeout", HikariConfig::setConnectionTimeout, 5000L);
+        setLongValue(section, config, "keepalive_time", HikariConfig::setKeepaliveTime, null);
+        setLongValue(section, config, "max_lifetime", HikariConfig::setMaxLifetime, null);
+        setLongValue(section, config, "idle_timeout", HikariConfig::setIdleTimeout, null);
+        setLongValue(section, config, "leak_detection_threshold", HikariConfig::setLeakDetectionThreshold, null);
+        setIntValue(section, config, "maximum_pool_size", HikariConfig::setMaximumPoolSize, null);
+        setIntValue(section, config, "minimum_idle", HikariConfig::setMinimumIdle, null);
+        setLongValue(section, config, "validation_timeout", HikariConfig::setValidationTimeout, null);
+        setLongValue(section, config, "initialization_fail_timeout", HikariConfig::setInitializationFailTimeout, null);
+
+    }
+
+    private static void setLongValue(
+            ConfigurationSection section, HikariConfig config, String path,
+            BiConsumer<HikariConfig, Long> apply, Long def
+    ) {
+        setIfExist(section, config, path ,apply, ConfigurationSection::getLong, def);
+    }
+
+    private static void setIntValue(
+            ConfigurationSection section, HikariConfig config, String path,
+            BiConsumer<HikariConfig, Integer> apply, Integer def
+    ) {
+        setIfExist(section, config, path ,apply, ConfigurationSection::getInt, def);
+    }
+
+    private static <T> void setIfExist(
+            ConfigurationSection section, HikariConfig config, String path,
+            BiConsumer<HikariConfig, T> apply,
+            BiFunction<ConfigurationSection, String, T> getter,
+            T def) {
+        T value = getter.apply(section, path);
+        if (value != null) {
+            apply.accept(config, value);
+        } else {
+            apply.accept(config, def);
+        }
+    }
+
+    private URI buildDatabaseUri(ConfigurationSection configSection) throws URISyntaxException {
+        String host = configSection.getString("host", "localhost");
+        int port = configSection.getInt("port", 3306);
+        String database = configSection.getString("database", "database");
+        if (!database.startsWith("/")) database = "/" + database;
+        return  new URI("jdbc:mysql", null, host, port, database, null, null);
+    }
+
+    public String getDatabase() {
+        return database;
     }
 
     public HikariDataSource getHikari() {

--- a/src/main/java/pk/ajneb97/database/MySQLConnection.java
+++ b/src/main/java/pk/ajneb97/database/MySQLConnection.java
@@ -1,6 +1,8 @@
 package pk.ajneb97.database;
 
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.MemoryConfiguration;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.scheduler.BukkitRunnable;
 import pk.ajneb97.PlayerKits2;
@@ -18,11 +20,6 @@ public class MySQLConnection {
 
     private PlayerKits2 plugin;
     private HikariConnection connection;
-    private String host;
-    private String database;
-    private String username;
-    private String password;
-    private int port;
 
     public MySQLConnection(PlayerKits2 plugin){
         this.plugin = plugin;
@@ -31,12 +28,9 @@ public class MySQLConnection {
     public void setupMySql(){
         FileConfiguration config = plugin.getConfigsManager().getMainConfigManager().getConfig();
         try {
-            host = config.getString("mysql_database.host");
-            port = Integer.valueOf(config.getString("mysql_database.port"));
-            database = config.getString("mysql_database.database");
-            username = config.getString("mysql_database.username");
-            password = config.getString("mysql_database.password");
-            connection = new HikariConnection(host,port,database,username,password);
+            ConfigurationSection section = config.getConfigurationSection("mysql_database");
+            if (section == null) section = new MemoryConfiguration();
+            connection = new HikariConnection(section);
             connection.getHikari().getConnection();
             createTables();
             loadData();
@@ -48,7 +42,7 @@ public class MySQLConnection {
 
 
     public String getDatabase() {
-        return this.database;
+        return connection.getDatabase();
     }
 
     public Connection getConnection() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -50,3 +50,18 @@ mysql_database:
   username: root
   password: root
   database: database
+  driver_properties:
+    autoReconnect: true
+    leakDetectionThreshold: true
+    verifyServerCertificate: false
+    useSSL: false
+  hikari_config:
+    connection_timeout: 5000
+    keepalive_time: null
+    max_lifetime: null
+    idle_timeout: null
+    leak_detection_threshold: null
+    maximum_pool_size: null
+    minimum_idle: null
+    validation_timeout: null
+    initialization_fail_timeout: null


### PR DESCRIPTION
At the moment, due to the database settings,  I am getting the following errors
```
[WARN]: [pk.ajneb97.libs.hikaricp.pool.PoolBase] HikariPool-1 - Failed to validate connection com.mysql.cj.jdbc.ConnectionImpl@9e24b8 (No operations allowed after connection closed.). Possibly consider using a shorter maxLifetime value.
[WARN]: [pk.ajneb97.libs.hikaricp.pool.PoolBase] HikariPool-1 - Failed to validate connection com.mysql.cj.jdbc.ConnectionImpl@6504cbea (No operations allowed after connection closed.). Possibly consider using a shorter maxLifetime value.
[WARN]: [pk.ajneb97.libs.hikaricp.pool.PoolBase] HikariPool-1 - Failed to validate connection com.mysql.cj.jdbc.ConnectionImpl@5ec8a585 (No operations allowed after connection closed.). Possibly consider using a shorter maxLifetime value.
[WARN]: [pk.ajneb97.libs.hikaricp.pool.PoolBase] HikariPool-1 - Failed to validate connection com.mysql.cj.jdbc.ConnectionImpl@46c54bd7 (No operations allowed after connection closed.). Possibly consider using a shorter maxLifetime value.
[WARN]: [pk.ajneb97.libs.hikaricp.pool.PoolBase] HikariPool-1 - Failed to validate connection com.mysql.cj.jdbc.ConnectionImpl@2218fcfe (No operations allowed after connection closed.). Possibly consider using a shorter maxLifetime value.
[WARN]: [pk.ajneb97.libs.hikaricp.pool.PoolBase] HikariPool-1 - Failed to validate connection com.mysql.cj.jdbc.ConnectionImpl@ae62234 (No operations allowed after connection closed.). Possibly consider using a shorter maxLifetime value.
```
These improvements can help me and other users fix these errors and make connection configuration more flexible.